### PR TITLE
fix: バックエンドからymlファイルを取得

### DIFF
--- a/next-app/OpenApi/Makefile
+++ b/next-app/OpenApi/Makefile
@@ -1,3 +1,4 @@
 
 open-api:
+	curl https://raw.githubusercontent.com/yuzuki-aritomo/ReserveTaskBackend/master/docs/swagger.yaml > swagger.yaml
 	docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate -i /local/swagger.yaml -g typescript-fetch -o /local/types/


### PR DESCRIPTION
下記コマンドでバックエンドのswagger.yamフィルを取得してopen api generaterを使用する。
`curl https://raw.githubusercontent.com/yuzuki-aritomo/ReserveTaskBackend/master/docs/swagger.yaml > swagger.yaml`
